### PR TITLE
修复创建连接池时指定编码无效的Bug

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.15
+current_version = 0.5.16
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 from setuptools import setup, find_packages
 
 package = 'tornado_battery'
-version = '0.5.15'
+version = '0.5.16'
 
 setup(
     name=package,


### PR DESCRIPTION
`create_pool` 方法写死了 `utf8` 😂 