### PR TITLE
Migrating from master-slave jargon

### DIFF
--- a/examples/greetings/greetings/entry.py
+++ b/examples/greetings/greetings/entry.py
@@ -20,14 +20,14 @@ class GreetingServer(HTTPServerEntryBase):
     routes = routes
 
     def init_options(self, io_loop):
-        register_postgres_options('master',
+        register_postgres_options('main',
                                   'postgres://devel:d3v3l@localhost/devel')
-        register_postgres_options('slave',
+        register_postgres_options('subordinate',
                                   'postgres://devel:d3v3l@localhost/devel')
 
     def init_app(self, io_loop):
-        io_loop.run_sync(connect_postgres('master'))
-        io_loop.run_sync(connect_postgres('slave'))
+        io_loop.run_sync(connect_postgres('main'))
+        io_loop.run_sync(connect_postgres('subordinate'))
 
 
 start = GreetingServer()

--- a/examples/greetings/greetings/routes/greeting.py
+++ b/examples/greetings/greetings/routes/greeting.py
@@ -20,7 +20,7 @@ class QuoteList(Schema):
 class AddController(RequestHandler):
 
     @schema(reply=QuoteList(strict=True))
-    @with_postgres(name='slave')
+    @with_postgres(name='subordinate')
     async def get(self, db):
         async with db.cursor() as cursor:
             await cursor.execute('SELECT quote FROM quotes ORDER BY RANDOM()')
@@ -30,7 +30,7 @@ class AddController(RequestHandler):
         return dict(code=0, msg='ok', data=dict(quotes=rows))
 
     @schema(json=Quote(strict=True), reply=True)
-    @with_postgres(name='master')
+    @with_postgres(name='main')
     async def post(self, db, json):
         async with db.cursor() as cursor:
             await cursor.execute('INSERT INTO quotes(quote) VALUES(%(quote)s)',

--- a/examples/greetings_mysql/greetings_mysql/command.py
+++ b/examples/greetings_mysql/greetings_mysql/command.py
@@ -23,14 +23,14 @@ LOG = logging.getLogger("app.biz")
 @route("/api/v1/greetings_mysql")
 class AddController(JSONController):
 
-    @with_mysql(name="slave")
+    @with_mysql(name="subordinate")
     async def get(self, db):
         async with db.cursor() as cursor:
             await cursor.execute("SELECT quote FROM quotes ORDER BY RAND()")
             row = await cursor.fetchone()
         self.reply(quote=row[0])
 
-    @with_mysql(name="master")
+    @with_mysql(name="main")
     async def post(self, db):
         async with db.cursor() as cursor:
             await cursor.execute("INSERT INTO quotes(quote) VALUES(%(quote)s)",
@@ -41,12 +41,12 @@ class AddController(JSONController):
 class GreetingServer(CommandMixin):
 
     def setup(self, io_loop):
-        register_mysql_options("master", "mysql://root:root@172.17.0.2/test")
-        register_mysql_options("slave", "mysql://root:root@172.17.0.2/test")
+        register_mysql_options("main", "mysql://root:root@172.17.0.2/test")
+        register_mysql_options("subordinate", "mysql://root:root@172.17.0.2/test")
 
     def before_run(self, io_loop):
-        io_loop.run_sync(connect_mysql("master"))
-        io_loop.run_sync(connect_mysql("slave"))
+        io_loop.run_sync(connect_mysql("main"))
+        io_loop.run_sync(connect_mysql("subordinate"))
 
         app = WebApplication(route.get_routes(), autoreload=options.debug)
         app.listen(8000, "0.0.0.0")

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -157,5 +157,5 @@ async def test_invalid_connection_scheme():
 async def test_option_name():
     from tornado_battery.mysql import option_name
 
-    assert option_name('master', 'uri') == 'mysql-master-uri'
-    assert option_name('slave', 'uri') == 'mysql-slave-uri'
+    assert option_name('main', 'uri') == 'mysql-main-uri'
+    assert option_name('subordinate', 'uri') == 'mysql-subordinate-uri'

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -40,20 +40,20 @@ def test_singleton():
 
 
 def test_named_singleton():
-    NamedSingle2.instance('master')
-    NamedSingle2.instance('slave')
-    master_id = id(NamedSingle1.instance('master'))
-    master_ids = [id(NamedSingle1.instance('master')) == master_id
+    NamedSingle2.instance('main')
+    NamedSingle2.instance('subordinate')
+    main_id = id(NamedSingle1.instance('main'))
+    main_ids = [id(NamedSingle1.instance('main')) == main_id
                   for i in range(0, 100)]
-    assert all(master_ids)
+    assert all(main_ids)
 
-    slave_id = id(NamedSingle1.instance('slave'))
-    slave_ids = [id(NamedSingle1.instance('slave')) == slave_id
+    subordinate_id = id(NamedSingle1.instance('subordinate'))
+    subordinate_ids = [id(NamedSingle1.instance('subordinate')) == subordinate_id
                  for i in range(0, 100)]
-    assert all(slave_ids)
+    assert all(subordinate_ids)
 
-    assert master_id != slave_id
-    assert (id(NamedSingle1.instance('master')) !=
-            id(NamedSingle2.instance('master')))
-    assert (id(NamedSingle1.instance('slave')) !=
-            id(NamedSingle2.instance('slave')))
+    assert main_id != subordinate_id
+    assert (id(NamedSingle1.instance('main')) !=
+            id(NamedSingle2.instance('main')))
+    assert (id(NamedSingle1.instance('subordinate')) !=
+            id(NamedSingle2.instance('subordinate')))

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -72,5 +72,5 @@ async def test_invalid_connection_scheme():
 async def test_option_name():
     from tornado_battery.postgres import option_name
 
-    assert option_name('master', 'uri') == 'postgres-master-uri'
-    assert option_name('slave', 'uri') == 'postgres-slave-uri'
+    assert option_name('main', 'uri') == 'postgres-main-uri'
+    assert option_name('subordinate', 'uri') == 'postgres-subordinate-uri'

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -64,5 +64,5 @@ async def test_no_connection():
 async def test_option_name():
     from tornado_battery.queue import option_name
 
-    assert option_name('master', 'uri') == 'queue-master-uri'
-    assert option_name('slave', 'uri') == 'queue-slave-uri'
+    assert option_name('main', 'uri') == 'queue-main-uri'
+    assert option_name('subordinate', 'uri') == 'queue-subordinate-uri'

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -90,5 +90,5 @@ async def test_invalid_connection_scheme():
 async def test_option_name():
     from tornado_battery.redis import option_name
 
-    assert option_name('master', 'uri') == 'redis-master-uri'
-    assert option_name('slave', 'uri') == 'redis-slave-uri'
+    assert option_name('main', 'uri') == 'redis-main-uri'
+    assert option_name('subordinate', 'uri') == 'redis-subordinate-uri'

--- a/tornado_battery/mysql.py
+++ b/tornado_battery/mysql.py
@@ -90,7 +90,7 @@ def option_name(instance: str, option: str) -> str:
     return f'mysql-{instance}-{option}'
 
 
-def register_mysql_options(instance: str='master',
+def register_mysql_options(instance: str='main',
                            default_uri: str='mysql://'):
     define(option_name(instance, 'uri'),
            default=default_uri,

--- a/tornado_battery/postgres.py
+++ b/tornado_battery/postgres.py
@@ -78,7 +78,7 @@ def option_name(instance: str, option: str) -> str:
     return f'postgres-{instance}-{option}'
 
 
-def register_postgres_options(instance: str='master',
+def register_postgres_options(instance: str='main',
                               default_uri: str='postgres://'):
     define(option_name(instance, 'uri'),
            default=default_uri,

--- a/tornado_battery/queue.py
+++ b/tornado_battery/queue.py
@@ -91,7 +91,7 @@ def option_name(instance: str, option: str) -> str:
     return f'queue-{instance}-{option}'
 
 
-def register_queue_options(instance: str='master',
+def register_queue_options(instance: str='main',
                            default_uri: str='amqp://'):
     define(option_name(instance, 'uri'),
            default=default_uri,

--- a/tornado_battery/redis.py
+++ b/tornado_battery/redis.py
@@ -89,7 +89,7 @@ def option_name(instance: str, option: str) -> str:
     return f'redis-{instance}-{option}'
 
 
-def register_redis_options(instance: str = 'master',
+def register_redis_options(instance: str = 'main',
                            default_uri: str = 'redis://'):
     define(option_name(instance, 'uri'),
            default=default_uri,


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.